### PR TITLE
Check record name case insensitive

### DIFF
--- a/src/Updater.php
+++ b/src/Updater.php
@@ -496,7 +496,7 @@ class Updater extends BaseQuery {
      * @throws Exception
      */
     private function _checkName( string $i_name ) : void {
-        if ( ! preg_match( '/' . $this->packet->question[ 0 ]->qName . '$/', $i_name ) ) {
+        if ( ! preg_match( '/' . $this->packet->question[ 0 ]->qName . '$/i', $i_name ) ) {
 
             throw new Exception(
                 'name provided (' . $i_name . ') does not match zone name (' .


### PR DESCRIPTION
@jdwx RFC allows to have record names with uppercases so `checkName` should be case insensitive.

https://datatracker.ietf.org/doc/html/rfc4343

Exemple :
Today, impossible to delete the following record :
`www.MYSITE.EG.  A 1.2.3.4` on zone `mysite.eg`
=> `name provided (www.MYSITE.EG) does not match zone name (mysite.eg)`
