### PR TITLE
Fix buildstring parsing for escaped quote

### DIFF
--- a/src/RR/RR.php
+++ b/src/RR/RR.php
@@ -530,7 +530,11 @@ abstract class RR {
         }
 
         foreach ( $data as $index => $string ) {
-            $data[ $index ] = str_replace( '\"', '"', trim( $string, '"' ) );
+            $data[ $index ] = str_replace(
+                '\"',
+                '"',
+                ( strlen( $string ) >= 2 && $string[0] === '"' && $string[-1] === '"' ) ? substr( $string, 1, -1 ) : $string
+            );
         }
 
         return $data;


### PR DESCRIPTION
When parsing a DNS TXT record whose value contains escaped double quotes (\"), buildString() produces a trailing backslash instead of the expected closing double quote.

The string passed to fromString() has this shape in the rdata part:
`"\"v=DKIM1; k=rsa; p=ABC123\""`

- Expected parsed value: `"v=DKIM1; k=rsa; p=ABC123"`
Actual parsed value:   `"v=DKIM1; k=rsa; p=ABC123\`


@jdwx 